### PR TITLE
pin flutter_map to v0.9.0 and also use single quotes for dart sdk pin.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,12 +5,12 @@ homepage: https://github.com/mat8854/
 repository: https://github.com/mat8854/lat_lon_grid_plugin
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: '>=2.1.0 <3.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
-  flutter_map: ^0.8.2
+  flutter_map: '>=0.8.2 <0.10.0'
   latlong: ^0.6.1
 
 dev_dependencies:


### PR DESCRIPTION
the strange writing way is done to be compatible with flutter_map_marker_cluster