### PR TITLE
update to flutter_map 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Adds a latitude / longitude grid as plugin to the [flutter_map](https://github.c
 
 Example application under `/example/`:
 
-![Example](lat_lon_grid_plugin_example.png)
+<img src="lat_lon_grid_plugin_example.png" alt="screenshot" height="1000"/>
 
 # Usage
 
@@ -20,8 +20,6 @@ dependencies:
 
 Include the `FlutterMap` into your widget tree.
 
-Please note: Make sure to place the `MapPluginLatLonGridOptions()` right after `TileLayerOptions()` so it does not consume touch events from other layer widgets.
-
 ```dart
   FlutterMap(
     mapController: _mapController,
@@ -29,32 +27,31 @@ Please note: Make sure to place the `MapPluginLatLonGridOptions()` right after `
       center: LatLng(51.814, -2.170),
       zoom: 6.15,
       rotation: 0.0,
-      plugins: [
-        MapPluginLatLonGrid(),
-      ],
     ),
-    layers: [
-      TileLayerOptions(
+    children: [
+      TileLayer(
         urlTemplate:
             'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
         subdomains: ['a', 'b', 'c'],
       ),
-      MapPluginLatLonGridOptions(
-        lineWidth: 0.5,
-        // apply alpha for grid lines
-        lineColor: Color.fromARGB(100, 0, 0, 0),
-        labelStyle: TextStyle(
-          color: Colors.white,
-          backgroundColor: Colors.black,
-          fontSize: 12.0,
+      LatLonGridLayer(
+        options: LatLonGridLayerOptions(
+          lineWidth: 0.5,
+          // apply alpha for grid lines
+          lineColor: Color.fromARGB(100, 0, 0, 0),
+          labelStyle: TextStyle(
+            color: Colors.white,
+            backgroundColor: Colors.black,
+            fontSize: 12.0,
+          ),
+          showCardinalDirections: true,
+          showCardinalDirectionsAsPrefix: false,
+          showLabels: true,
+          rotateLonLabels: true,
+          placeLabelsOnLines: true,
+          offsetLonLabelsBottom: 20.0,
+          offsetLatLabelsLeft: 20.0,
         ),
-        showCardinalDirections: true,
-        showCardinalDirectionsAsPrefix: false,
-        showLabels: true,
-        rotateLonLabels: true,
-        placeLabelsOnLines: true,
-        offsetLonLabelsBottom: 20.0,
-        offsetLatLabelsLeft: 20.0,
       ),
     ],
   ),

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -37,8 +37,7 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId "com.example.example"
+        applicationId "com.lat_long_grid_plugin.example"
         minSdkVersion 16
         targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()

--- a/example/android/app/src/debug/AndroidManifest.xml
+++ b/example/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.example">
+    package="com.lat_long_grid_plugin.example">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.example">
+    package="com.lat_long_grid_plugin.example">
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that
          calls FlutterMain.startInitialization(this); in its onCreate method.
          In most cases you can leave this as-is, but you if you want to provide
@@ -7,7 +7,7 @@
          FlutterApplication and put your custom class here. -->
     <application
         android:name="${applicationName}"
-        android:label="example"
+        android:label="lat_long_grid_plugin"
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"

--- a/example/android/app/src/main/kotlin/com/example/example/MainActivity.kt
+++ b/example/android/app/src/main/kotlin/com/example/example/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.example
+package com.lat_long_grid_plugin.example
 
 import androidx.annotation.NonNull;
 import io.flutter.embedding.android.FlutterActivity

--- a/example/android/app/src/profile/AndroidManifest.xml
+++ b/example/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.example">
+    package="com.lat_long_grid_plugin.example">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -97,32 +97,31 @@ class _HomePageState extends State<HomePage> {
               zoom: 6.15,
               rotation: 0.0,
               onPositionChanged: (position, hasGesture) => _updateLabel(),
-              plugins: [
-                MapPluginLatLonGrid(),
-              ],
             ),
-            layers: [
-              TileLayerOptions(
+            children: [
+              TileLayer(
                 urlTemplate:
                     'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
                 subdomains: ['a', 'b', 'c'],
               ),
-              MapPluginLatLonGridOptions(
-                lineWidth: 0.5,
-                // apply alpha for grid lines
-                lineColor: Color.fromARGB(100, 0, 0, 0),
-                labelStyle: TextStyle(
-                  color: Colors.white,
-                  backgroundColor: Colors.black,
-                  fontSize: 12.0,
+              LatLonGridLayer(
+                options: LatLonGridLayerOptions(
+                  lineWidth: 0.5,
+                  // apply alpha for grid lines
+                  lineColor: Color.fromARGB(100, 0, 0, 0),
+                  labelStyle: TextStyle(
+                    color: Colors.white,
+                    backgroundColor: Colors.black,
+                    fontSize: 12.0,
+                  ),
+                  showCardinalDirections: true,
+                  showCardinalDirectionsAsPrefix: false,
+                  showLabels: true,
+                  rotateLonLabels: true,
+                  placeLabelsOnLines: true,
+                  offsetLonLabelsBottom: 20.0,
+                  offsetLatLabelsLeft: 20.0,
                 ),
-                showCardinalDirections: true,
-                showCardinalDirectionsAsPrefix: false,
-                showLabels: true,
-                rotateLonLabels: true,
-                placeLabelsOnLines: true,
-                offsetLonLabelsBottom: 20.0,
-                offsetLatLabelsLeft: 20.0,
               ),
             ],
           ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,21 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
@@ -56,7 +49,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -68,7 +61,7 @@ packages:
       name: flutter_map
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -80,14 +73,14 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.3"
+    version: "0.13.5"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.1"
   intl:
     dependency: transitive
     description:
@@ -101,42 +94,42 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.2"
+    version: "0.2.3"
   latlong2:
     dependency: transitive
     description:
       name: latlong2
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.0"
+    version: "0.8.1"
   lists:
     dependency: transitive
     description:
       name: lists
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -150,14 +143,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.11.0"
+    version: "1.8.2"
   polylabel:
     dependency: transitive
     description:
@@ -178,14 +164,14 @@ packages:
       name: proj4dart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   quiver:
     dependency: transitive
     description:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -197,7 +183,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -218,28 +204,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
-  transparent_image:
-    dependency: transitive
-    description:
-      name: transparent_image
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
+    version: "0.4.12"
   tuple:
     dependency: transitive
     description:
@@ -253,14 +232,14 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   unicode:
     dependency: transitive
     description:
       name: unicode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.1"
   vector_math:
     dependency: transitive
     description:
@@ -276,5 +255,5 @@ packages:
     source: hosted
     version: "2.0.0"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
-  flutter: ">=2.0.0"
+  dart: ">=2.17.0 <3.0.0"
+  flutter: ">=3.3.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_map: '2.0.0'
+  flutter_map: '3.0.0'
   lat_lon_grid_plugin:
     path: ../
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,4 +1,4 @@
-name: example
+name: lat_lon_grid_plugin_example
 description: Lat lon grid plugin flutter map example
 
 # The following defines the version and build number for your application.

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,7 +14,7 @@ description: Lat lon grid plugin flutter map example
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
   flutter:

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -8,7 +8,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:example/main.dart';
+import 'package:lat_lon_grid_plugin_example/main.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {

--- a/lib/lat_lon_grid_plugin.dart
+++ b/lib/lat_lon_grid_plugin.dart
@@ -4,8 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/plugin_api.dart';
 import 'package:latlong2/latlong.dart';
 
-/// MapPluginLatLonGridOptions
-class MapPluginLatLonGridOptions extends LayerOptions {
+/// LatLonGridLayerOptions
+class LatLonGridLayerOptions {
   /// color of grid lines
   Color lineColor;
 
@@ -39,8 +39,8 @@ class MapPluginLatLonGridOptions extends LayerOptions {
   /// offset for latitude labels from the 'left' (north up)
   double offsetLatLabelsLeft = 75;
 
-  /// MapPluginLatLonGridOptions
-  MapPluginLatLonGridOptions({
+  /// LatLonGridLayerOptions
+  LatLonGridLayerOptions({
     required this.labelStyle,
     this.lineWidth = 0.5,
     this.lineColor = Colors.black,
@@ -73,34 +73,25 @@ class MapPluginLatLonGridOptions extends LayerOptions {
   final bool _groupedLabelCalls = true;
 }
 
-/// MapPluginLatLonGrid
-class MapPluginLatLonGrid implements MapPlugin {
-  /// MapPluginLatLonGridOptions
-  final MapPluginLatLonGridOptions? options;
+/// LatLonGridLayer
+class LatLonGridLayer extends StatelessWidget {
+  /// LatLonGridLayerOptions
+  final LatLonGridLayerOptions options;
 
   /// Plugin options
-  MapPluginLatLonGrid({this.options});
+  LatLonGridLayer({super.key, required this.options});
 
   @override
-  Widget createLayer(
-      LayerOptions options, MapState mapState, Stream<void> stream) {
-    if (options is MapPluginLatLonGridOptions) {
-      return Center(
-        child: CustomPaint(
-          // the child empty Container ensures that CustomPainter gets a size
-          // (not w=0 and h=0)
-          child: Container(),
-          painter: _LatLonPainter(options: options, mapState: mapState),
-        ),
-      );
-    }
-
-    throw Exception('Unknown options type for MyCustom plugin: $options');
-  }
-
-  @override
-  bool supportsLayer(LayerOptions options) {
-    return options is MapPluginLatLonGridOptions;
+  Widget build(BuildContext context) {
+    final mapState = FlutterMapState.maybeOf(context)!;
+    return Center(
+      child: CustomPaint(
+        // the child empty Container ensures that CustomPainter gets a size
+        // (not w=0 and h=0)
+        child: Container(),
+        painter: _LatLonPainter(options: options, mapState: mapState),
+      ),
+    );
   }
 }
 
@@ -120,8 +111,8 @@ class _GridLabel {
 class _LatLonPainter extends CustomPainter {
   double w = 0.0;
   double h = 0.0;
-  MapPluginLatLonGridOptions options;
-  MapState mapState;
+  final LatLonGridLayerOptions options;
+  final FlutterMapState mapState;
   final Paint mPaint = Paint();
 
   // list of grid labels for latitude and longitude
@@ -159,7 +150,7 @@ class _LatLonPainter extends CustomPainter {
     TextPainter textPainterMax = getTextPaint('180W');
     // maximal width for this label text
     double textPainterMaxW = textPainterMax.width;
-    // height is equal for all unrotated labels
+    // height is equal for all not rotated labels
     double textPainterH = textPainterMax.height;
 
     // draw north-south lines
@@ -247,7 +238,7 @@ class _LatLonPainter extends CustomPainter {
   // search the console for the final results printed after sample count is collected
   void addTimeForProfiling(int time) {
     // do add / calc logic
-    if (options._profilingValCount < MapPluginLatLonGridOptions._samples) {
+    if (options._profilingValCount < LatLonGridLayerOptions._samples) {
       // add time
       options._profilingVals[options._profilingValCount] = time;
       options._profilingValCount++;
@@ -256,11 +247,11 @@ class _LatLonPainter extends CustomPainter {
       // use "effective integer division" as suggested from IDE
       options._profilingVals.sort();
       int median = options
-          ._profilingVals[(MapPluginLatLonGridOptions._samples - 1) ~/ 2];
+          ._profilingVals[(LatLonGridLayerOptions._samples - 1) ~/ 2];
 
       // print median once to console
       print(
-          'median of draw() is $median us (out of ${MapPluginLatLonGridOptions._samples} samples)');
+          'median of draw() is $median us (out of ${LatLonGridLayerOptions._samples} samples)');
       // reset counter
       options._profilingValCount = 0;
     }

--- a/lib/lat_lon_grid_plugin.dart
+++ b/lib/lat_lon_grid_plugin.dart
@@ -7,37 +7,37 @@ import 'package:latlong2/latlong.dart';
 /// LatLonGridLayerOptions
 class LatLonGridLayerOptions {
   /// color of grid lines
-  Color lineColor;
+  final Color lineColor;
 
   /// width of grid lines
   /// can be adjusted even down to 0.1 on high res displays for a light grid
-  double lineWidth = 0.5;
+  final double lineWidth;
 
   /// style of labels
-  TextStyle labelStyle;
+  final TextStyle labelStyle;
 
   /// show cardinal directions instead of numbers only
   // prevents negative numbers, e.g. 45.5W instead of -45.5
-  bool showCardinalDirections = false;
+  final bool showCardinalDirections;
 
   /// show cardinal direction as prefix, e.g. W45.5 instead of 45.5W
-  bool showCardinalDirectionsAsPrefix = false;
+  final bool showCardinalDirectionsAsPrefix;
 
   /// enable labels
-  bool showLabels = true;
+  final bool showLabels;
 
   /// rotate longitude labels 90 degrees
   /// mainly to prevent overlapping on high zoom levels
-  bool rotateLonLabels = true;
+  final bool rotateLonLabels;
 
   /// center labels on lines instead of top edge alignment
-  bool placeLabelsOnLines = true;
+  final bool placeLabelsOnLines;
 
   /// offset for longitude labels from the 'bottom' (north up)
-  double offsetLonLabelsBottom = 50;
+  final double offsetLonLabelsBottom;
 
   /// offset for latitude labels from the 'left' (north up)
-  double offsetLatLabelsLeft = 75;
+  final double offsetLatLabelsLeft;
 
   /// LatLonGridLayerOptions
   LatLonGridLayerOptions({
@@ -86,9 +86,9 @@ class LatLonGridLayer extends StatelessWidget {
     final mapState = FlutterMapState.maybeOf(context)!;
     return Center(
       child: CustomPaint(
-        // the child empty Container ensures that CustomPainter gets a size
+        // the child SizedBox.expand() ensures that CustomPainter gets a size
         // (not w=0 and h=0)
-        child: Container(),
+        child: SizedBox.expand(),
         painter: _LatLonPainter(options: options, mapState: mapState),
       ),
     );
@@ -116,8 +116,8 @@ class _LatLonPainter extends CustomPainter {
   final Paint mPaint = Paint();
 
   // list of grid labels for latitude and longitude
-  List<_GridLabel> lonGridLabels = [];
-  List<_GridLabel> latGridLabels = [];
+  final List<_GridLabel> lonGridLabels = [];
+  final List<_GridLabel> latGridLabels = [];
 
   _LatLonPainter({required this.options, required this.mapState}) {
     mPaint.color = options.lineColor;
@@ -134,38 +134,38 @@ class _LatLonPainter extends CustomPainter {
     w = size.width;
     h = size.height;
 
-    List<double> inc = getIncrementor(mapState.zoom.round());
+    final List<double> inc = getIncrementor(mapState.zoom.round());
 
     // store bounds
     // mapState.bounds cannot actually be null
-    double north = mapState.bounds.north;
-    double west = mapState.bounds.west;
-    double south = mapState.bounds.south;
-    double east = mapState.bounds.east;
+    final north = mapState.bounds.north;
+    final west = mapState.bounds.west;
+    final south = mapState.bounds.south;
+    final east = mapState.bounds.east;
 
-    Bounds b = mapState.getPixelBounds(mapState.zoom);
-    CustomPoint topLeftPixel = b.topLeft;
+    final bounds = mapState.getPixelBounds(mapState.zoom);
+    final CustomPoint topLeftPixel = bounds.topLeft;
 
     // getting the dimensions for a maximal sized text label
-    TextPainter textPainterMax = getTextPaint('180W');
+    final TextPainter textPainterMax = getTextPaint('180W');
     // maximal width for this label text
-    double textPainterMaxW = textPainterMax.width;
+    final double textPainterMaxW = textPainterMax.width;
     // height is equal for all not rotated labels
-    double textPainterH = textPainterMax.height;
+    final double textPainterH = textPainterMax.height;
 
     // draw north-south lines
-    List<double> lonPos = generatePositions(
+    final List<double> lonPos = generatePositions(
         west, east, inc[0], options._enableOverscan, -180.0, 180.0);
     lonGridLabels.clear();
     for (int i = 0; i < lonPos.length; i++) {
       // convert point to pixels
-      CustomPoint projected =
+      final CustomPoint projected =
           mapState.project(LatLng(north, lonPos[i]), mapState.zoom);
-      double pixelPos = projected.x - (topLeftPixel.x as double);
+      final double pixelPos = projected.x - (topLeftPixel.x as double);
 
       // draw line
-      Offset pTopNorth = Offset(pixelPos, 0.0);
-      Offset pBottomSouth = Offset(pixelPos, h);
+      final pTopNorth = Offset(pixelPos, 0.0);
+      final pBottomSouth = Offset(pixelPos, h);
       // only draw visible lines, using one complete line width as buffer
       if (pixelPos + options.lineWidth >= 0.0 &&
           pixelPos - options.lineWidth <= w) {
@@ -189,18 +189,18 @@ class _LatLonPainter extends CustomPainter {
     }
 
     // draw west-east lines
-    List<double> latPos = generatePositions(
+    final List<double> latPos = generatePositions(
         south, north, inc[0], options._enableOverscan, -90.0, 90.0);
     latGridLabels.clear();
     for (int i = 0; i < latPos.length; i++) {
       // convert back to pixels
-      CustomPoint projected =
+      final CustomPoint projected =
           mapState.project(LatLng(latPos[i], east), mapState.zoom);
-      double pixelPos = projected.y - (topLeftPixel.y as double);
+      final double pixelPos = projected.y - (topLeftPixel.y as double);
 
       // draw line
-      Offset pLeftWest = Offset(0.0, pixelPos);
-      Offset pRightEast = Offset(w, pixelPos);
+      final pLeftWest = Offset(0.0, pixelPos);
+      final pRightEast = Offset(w, pixelPos);
       // only draw visible lines, using one complete line width as buffer
       if (pixelPos + options.lineWidth >= 0.0 &&
           pixelPos - options.lineWidth <= h) {
@@ -246,7 +246,7 @@ class _LatLonPainter extends CustomPainter {
       // calc median here, not using mean here
       // use "effective integer division" as suggested from IDE
       options._profilingVals.sort();
-      int median = options
+      final int median = options
           ._profilingVals[(LatLonGridLayerOptions._samples - 1) ~/ 2];
 
       // print median once to console
@@ -262,7 +262,7 @@ class _LatLonPainter extends CustomPainter {
   void drawLabels(Canvas canvas, List<_GridLabel> list) {
     // process items to generate text painter
     for (int i = 0; i < list.length; i++) {
-      String sText = getText(list[i].degree, list[i].digits, list[i].isLat);
+      final sText = getText(list[i].degree, list[i].digits, list[i].isLat);
       list[i].textPainter = getTextPaint(sText);
     }
 
@@ -273,11 +273,11 @@ class _LatLonPainter extends CustomPainter {
   // draw one text label
   void drawText(Canvas canvas, double degree, int digits, double posx,
       double posy, bool isLat) {
-    List<_GridLabel> list = [];
-    _GridLabel label = _GridLabel(degree, digits, posx, posy, isLat);
+    final list = <_GridLabel>[];
+    final label = _GridLabel(degree, digits, posx, posy, isLat);
 
     // generate textPainter object from input data
-    String sText = getText(degree, digits, isLat);
+    final sText = getText(degree, digits, isLat);
     label.textPainter = getTextPaint(sText);
 
     // do the actual draw call, pass a list with one item
@@ -301,7 +301,7 @@ class _LatLonPainter extends CustomPainter {
       // loop for draw calls
       for (int i = 0; i < list.length; i++) {
         // calc compensated position and draw
-        double xCompensated = -list[i].posy - list[i].textPainter.height;
+        final double xCompensated = -list[i].posy - list[i].textPainter.height;
         double yCompensated = list[i].posx;
         if (options.placeLabelsOnLines) {
           // apply additional offset
@@ -316,10 +316,12 @@ class _LatLonPainter extends CustomPainter {
       // loop for draw calls
       for (int i = 0; i < list.length; i++) {
         // calc offset to place labels on lines
-        double offsetX =
-            options.placeLabelsOnLines ? list[i].textPainter.width / 2 : 0.0;
-        double offsetY =
-            options.placeLabelsOnLines ? list[i].textPainter.height / 2 : 0.0;
+        double offsetX = options.placeLabelsOnLines
+            ? list[i].textPainter.width / 2
+            : 0.0;
+        double offsetY = options.placeLabelsOnLines
+            ? list[i].textPainter.height / 2
+            : 0.0;
 
         // reset unwanted offset depending on lat or lon
         list[i].isLat ? offsetX = 0.0 : offsetY = 0.0;
@@ -356,7 +358,7 @@ class _LatLonPainter extends CustomPainter {
     }
     // convert degree value to text
     // with defined digits amount after decimal point
-    String sDegree = '${degree.toStringAsFixed(digits)}°';
+    final sDegree = '${degree.toStringAsFixed(digits)}°';
 
     // build text string
     String sText = '';
@@ -381,7 +383,7 @@ class _LatLonPainter extends CustomPainter {
 
   TextPainter getTextPaint(String text) {
     // setup all text painter objects
-    TextSpan textSpan = TextSpan(style: options.labelStyle, text: text);
+    final textSpan = TextSpan(style: options.labelStyle, text: text);
     return TextPainter(text: textSpan, textDirection: TextDirection.ltr)
       ..layout();
   }
@@ -394,7 +396,7 @@ class _LatLonPainter extends CustomPainter {
   // Generate a list of doubles between start and end with spacing inc
   List<double> generatePositions(double start, double end, double inc,
       bool extendedRange, double lowerBound, double upperBound) {
-    List<double> list = [];
+    final list = <double>[];
 
     // find first value
     double currentPos = roundUp(start, inc);
@@ -405,15 +407,14 @@ class _LatLonPainter extends CustomPainter {
     assert(inc > 1E-5);
     assert(start < end);
     // calc upper limit for iterations
-    double upperLimit = (end - start) / inc;
+    final double upperLimit = (end - start) / inc;
     int counter = 0;
 
-    bool run = true;
-    while (run && counter <= upperLimit.ceil()) {
+    while (counter <= upperLimit.ceil()) {
       currentPos += inc;
       list.add(currentPos);
       if (currentPos >= end) {
-        run = false;
+        break;
       }
       counter++;
     }
@@ -437,10 +438,10 @@ class _LatLonPainter extends CustomPainter {
   // Taken from here: https://stackoverflow.com/questions/3407012/c-rounding-up-to-the-nearest-multiple-of-a-number
   double roundUp(double number, double fixedBase) {
     if (fixedBase != 0 && number != 0) {
-      double sign = number > 0 ? 1 : -1;
+      final double sign = number > 0 ? 1 : -1;
       number *= sign;
       number /= fixedBase;
-      int fixedPoint = number.ceil().toInt();
+      final int fixedPoint = number.ceil().toInt();
       number = fixedPoint * fixedBase;
       number *= sign;
     }
@@ -449,9 +450,9 @@ class _LatLonPainter extends CustomPainter {
 
   // Proven values taken from osmdroid LatLon function
   List<double> getIncrementor(int zoom) {
-    List<double> ret = [];
+    final ret = <double>[];
 
-    List<double> lineSpacingDegrees = [
+    const lineSpacingDegrees = <double>[
       45.0,
       30.0,
       15.0,
@@ -481,8 +482,7 @@ class _LatLonPainter extends CustomPainter {
     int index = zoom;
     if (zoom <= 0) {
       index = 0;
-    }
-    if (zoom > lineSpacingDegrees.length - 1) {
+    } else if (zoom > lineSpacingDegrees.length - 1) {
       index = lineSpacingDegrees.length - 1;
     }
     // pick the right spacing

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,21 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
@@ -49,7 +42,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -61,7 +54,7 @@ packages:
       name: flutter_map
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -73,14 +66,14 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.3"
+    version: "0.13.5"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.1"
   intl:
     dependency: transitive
     description:
@@ -94,35 +87,35 @@ packages:
       name: latlong2
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.0"
+    version: "0.8.1"
   lists:
     dependency: transitive
     description:
       name: lists
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -136,14 +129,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.11.0"
+    version: "1.8.2"
   polylabel:
     dependency: transitive
     description:
@@ -164,14 +150,14 @@ packages:
       name: proj4dart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   quiver:
     dependency: transitive
     description:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -183,7 +169,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -204,28 +190,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
-  transparent_image:
-    dependency: transitive
-    description:
-      name: transparent_image
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
+    version: "0.4.12"
   tuple:
     dependency: transitive
     description:
@@ -239,14 +218,14 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   unicode:
     dependency: transitive
     description:
       name: unicode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.1"
   vector_math:
     dependency: transitive
     description:
@@ -262,5 +241,5 @@ packages:
     source: hosted
     version: "2.0.0"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
-  flutter: ">=2.0.0"
+  dart: ">=2.17.0 <3.0.0"
+  flutter: ">=3.3.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/matthiasdittmer/
 repository: https://github.com/matthiasdittmer/lat_lon_grid_plugin
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
   flutter: '>=2.0.0'
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_map: '>=1.0.0'
+  flutter_map: '>=3.0.0'
   latlong2: '>=0.8.0'
 
 dev_dependencies:


### PR DESCRIPTION
Version 3.0 of `flutter_map` introduces breaking changes that require implementation changes to plugins.
- https://pub.dev/packages/flutter_map/changelog
- https://docs.fleaflet.dev/migration/to-v3.0.0

Here is a list with the changes in this pull request:
- upgrade packages
- bump minimum dart version to 2.17 (same as flutter_map)
- minimum version of flutter_map is 3.0, backwards support is not possible because of the new layering system
- use the naming convention of flutter_map
  - `MapPluginLatLonGridOptions` is now `LatLonGridLayerOptions`
  - `MapPluginLatLonGridOptions` is now `LatLonGridLayerOptions`
- use the new layering system (every layer is now a Widget)
- update the implementation of the example app
- minor performance improvements by using final and const
- bump gradle to 7.0 to get rid of a warning while building
- use custom app name and package id on android to prevent collision with other example apps
- update `README.md`
  - limit size of example screenshot
  - update example code