### PR TITLE
Fix render error when showLabels is false

### DIFF
--- a/lib/lat_lon_grid_plugin.dart
+++ b/lib/lat_lon_grid_plugin.dart
@@ -288,7 +288,9 @@ class _LatLonPainter extends CustomPainter {
   // can be used for a single item or list of items.
   void canvasCall(Canvas canvas, List<_GridLabel> list) {
     // check for at least on entry
-    assert(list.length > 0);
+    if (list.length == 0) {
+      return;
+    }
 
     // check for longitude and enabled rotation
     if (!list[0].isLat && options.rotateLonLabels) {


### PR DESCRIPTION
When showLabels is false, `canvasCall` will be called with an empty list of labels, throwing assert errors.